### PR TITLE
Modified to work on 0.91.2 and added functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Currently supports:
 - Reading current temperature
 - Reading target temperature
 - Setting target temperature
+- Changing hold_mode (i.e. preset)
+- Getting scheduled state (and schedules)
 
 ## Installation
 - Download release or the master branch as zip
@@ -19,4 +21,14 @@ climate:
     host: local_ip_address
     port: port_number
     scan_interval: 10
+```
+
+## Changing hold_mode
+
+This is done using HASS service `climate.set_hold_mode` with service data like:
+
+```json
+{
+  "entity_id": "climate.anna_thermostaat","hold_mode":"away"
+}
 ```

--- a/custom_components/anna/__init__.py
+++ b/custom_components/anna/__init__.py
@@ -1,0 +1,1 @@
+REQUIREMENTS = ['haanna==0.6.2']

--- a/custom_components/anna/climate.py
+++ b/custom_components/anna/climate.py
@@ -107,7 +107,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         )
     ])
 
-_LOGGER.info("Anna: custom component loading (Anna PlugWise climate)")
+_LOGGER.debug("Anna: custom component loading (Anna PlugWise climate)")
 
 class ThermostatDevice(ClimateDevice):
     """Representation of an Anna thermostat"""
@@ -133,9 +133,9 @@ class ThermostatDevice(ClimateDevice):
         try:
              self._api.ping_anna_thermostat()
         except:
-            _LOGGER.warning("Anna: Unable to ping, platform not ready")
+            _LOGGER.error("Anna: Unable to ping, platform not ready")
             raise PlatformNotReady
-        _LOGGER.info("Anna: platform ready")
+        _LOGGER.debug("Anna: platform ready")
         self.update()
 
     @property
@@ -220,7 +220,7 @@ class ThermostatDevice(ClimateDevice):
 
     def set_temperature(self, **kwargs):
         """Set new target temperature"""
-        _LOGGER.info("Anna: Adjusting temperature")
+        _LOGGER.debug("Anna: Adjusting temperature")
         import haanna
         temperature = kwargs.get(ATTR_TEMPERATURE)
         if temperature is not None and temperature > CONF_MIN_TEMP and temperature < CONF_MAX_TEMP:
@@ -234,7 +234,7 @@ class ThermostatDevice(ClimateDevice):
 
     def set_hold_mode(self, hold_mode):
         """Set the hold mode."""
-        _LOGGER.info("Anna: Adjusting hold_mode (i.e. preset)")
+        _LOGGER.debug("Anna: Adjusting hold_mode (i.e. preset)")
         if hold_mode is not None and hold_mode in HOLD_MODES:
             domain_objects = self._api.get_domain_objects()
             self._hold_mode = hold_mode

--- a/custom_components/anna/climate.py
+++ b/custom_components/anna/climate.py
@@ -12,7 +12,6 @@ climate:
     port: 80
     scan_interval: 10
 """
-REQUIREMENTS = ['haanna==0.6.2']
 
 import voluptuous as vol
 import logging

--- a/custom_components/anna/manifest.json
+++ b/custom_components/anna/manifest.json
@@ -2,7 +2,7 @@
   "domain": "anna",
   "name": "Plugwise_Anna",
   "documentation": "https://github.com/laetificat/anna-ha",
-  "dependencies": ["climate"],
+  "dependencies": [],
   "codeowners": ["@laetificat","CoMPaTech"],
   "requirements": ["haanna==0.6.2"]
 }

--- a/custom_components/anna/manifest.json
+++ b/custom_components/anna/manifest.json
@@ -1,0 +1,8 @@
+{
+  "domain": "anna",
+  "name": "Plugwise_Anna",
+  "documentation": "https://github.com/laetificat/anna-ha",
+  "dependencies": ["climate"],
+  "codeowners": ["@laetificat","CoMPaTech"],
+  "requirements": ["haanna==0.6.2"]
+}


### PR DESCRIPTION
Not sure if the heater 'on' detection works, but will try that in the coming days. If you rather put that in haanna that would be better I guess, or now I've put the generic idea here as I still have to tinker with it.

The current code doesn't seem to work under HASS 0.91.2, this PR solves that for me.

Great work, got Anna today and already loving it (in HASS!)

Also addded display of the current preset (home/away/asleep) - are you thinking of including this component in HASS itself? Updating https://community.home-assistant.io/t/advice-how-to-load-sensor-info-from-plugwise-anna-thermostat-web-interface-xml/87801/4 to have the community check on this as well.

Feedback is welcome!