### PR TITLE
Real final fix for update problem after 0.94.0

### DIFF
--- a/custom_components/anna/climate.py
+++ b/custom_components/anna/climate.py
@@ -50,8 +50,6 @@ from homeassistant.exceptions import PlatformNotReady
 SUPPORT_FLAGS = ( SUPPORT_TARGET_TEMPERATURE | SUPPORT_HOLD_MODE )
 #SUPPORT_FLAGS = ( SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE | SUPPORT_HOLD_MODE | SUPPORT_AWAY_MODE )
 
-REQUIREMENTS = ['haanna']
-
 _LOGGER = logging.getLogger(__name__)
 
 # Configuration directives

--- a/custom_components/anna/climate.py
+++ b/custom_components/anna/climate.py
@@ -18,8 +18,6 @@ import logging
 
 import xml.etree.cElementTree as Etree
 
-from haanna import Haanna
-
 from homeassistant.components.climate import (
     ClimateDevice,
     PLATFORM_SCHEMA)
@@ -52,6 +50,8 @@ from homeassistant.exceptions import PlatformNotReady
 SUPPORT_FLAGS = ( SUPPORT_TARGET_TEMPERATURE | SUPPORT_HOLD_MODE )
 #SUPPORT_FLAGS = ( SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE | SUPPORT_HOLD_MODE | SUPPORT_AWAY_MODE )
 
+REQUIREMENTS = ['haanna']
+
 _LOGGER = logging.getLogger(__name__)
 
 # Configuration directives
@@ -61,7 +61,6 @@ CONF_MAX_TEMP = 30
 DEFAULT_NAME = 'Anna Thermostat'
 DEFAULT_USERNAME = 'smile'
 DEFAULT_TIMEOUT = 10
-BASE_URL = 'http://{0}:{1}{2}'
 DEFAULT_ICON = "mdi:thermometer"
 
 # Hold modes
@@ -127,7 +126,8 @@ class ThermostatDevice(ClimateDevice):
         self._operation_list = DEFAULT_OPERATION_LIST
 
         _LOGGER.debug("Anna: Initializing API")
-        self._api = Haanna(self._username, self._password, self._host, self._port)
+        import haanna
+        self._api = haanna.Haanna(self._username, self._password, self._host, self._port)
         try:
              self._api.ping_anna_thermostat()
         except:

--- a/custom_components/anna/manifest.json
+++ b/custom_components/anna/manifest.json
@@ -1,0 +1,8 @@
+{
+  "domain": "anna",
+  "name": "Plugwise Anna",
+  "documentation": "https://github.com/laetificat/anna-ha",
+  "dependencies": [],
+  "codeowners": ["@laetificat","CoMPaTech"],
+  "requirements": ["haanna==0.8.0"]
+}

--- a/custom_components/anna/manifest.json
+++ b/custom_components/anna/manifest.json
@@ -1,8 +1,0 @@
-{
-  "domain": "anna",
-  "name": "Plugwise Anna",
-  "documentation": "https://github.com/laetificat/anna-ha",
-  "dependencies": [],
-  "codeowners": ["@laetificat","CoMPaTech"],
-  "requirements": ["haanna==0.8.0"]
-}


### PR DESCRIPTION
See my closed issue for more info.

Tested on my system, I rolled back to 0.94.4, made the changes in the PR, restarted HA, all working.
Then I updated to 0.95.1, all still working after the update.

When looking at the required code-changes it actually makes sense:
The REQUIREMENTS-line is moved from the climate.py file to the manifest.json file. The way to import the dependency and how to call it, stays the same.