### PR TITLE
Updated readme typo and re-added presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # Anna component for Home Assistant
 A custom component to monitor the Plugwise Anna thermostat in Home Assistant.  
+
 Currently supports:
+
 - Reading current temperature
 - Reading target temperature
 - Setting target temperature
 - Changing preset_mode 
+
 Todo:
+
 - Getting scheduled state (and schedules)
 - Making 'changing HVAC mode' work (changing HEAT to AUTO or likewise using the GUI generates an error ... it does show if Anna is heating though ;))
 

--- a/custom_components/anna/climate.py
+++ b/custom_components/anna/climate.py
@@ -5,49 +5,38 @@ configurations.yaml
 
 climate:
   - platform: anna
-    password: your_short_id   # required, the ID on the smile (some string of 6 characters)
+    password: your_short_id   # required, the ID on the smile (some string
+                              # of 6 characters)
     host: local_ip_address    # required, the IP-address of your smile
-    name: Anna Thermostat     # optional, only if you want to use a different name
+    name: Anna Thermostat     # optional, only if you want to use a
+                              # different name
     username: smile           # optional, default username is smile
     port: 80                  # optional, default port is 80
     scan_interval: 10         # optional, default scan interval is 10 seconds
+
+Originally by https://github.com/laetificat/anna-ha
 """
 
-import voluptuous as vol
 import logging
 
-import xml.etree.cElementTree as Etree
-
-from homeassistant.components.climate import (
-    ClimateDevice,
-    PLATFORM_SCHEMA)
-
-from homeassistant.components.climate.const import (
-    DOMAIN,
-    SUPPORT_TARGET_TEMPERATURE,
-    SUPPORT_PRESET_MODE,
-    HVAC_MODE_HEAT,
-    HVAC_MODE_AUTO,
-    HVAC_MODE_OFF,
-    SERVICE_SET_PRESET_MODE,
-    SERVICE_SET_TEMPERATURE,
-    CURRENT_HVAC_HEAT,
-    CURRENT_HVAC_IDLE)
-
-from homeassistant.const import (
-    CONF_NAME, 
-    CONF_HOST, 
-    CONF_PORT, 
-    CONF_USERNAME, 
-    CONF_PASSWORD, 
-    TEMP_CELSIUS, 
-    ATTR_TEMPERATURE)
-
 import homeassistant.helpers.config_validation as cv
-
+import voluptuous as vol
+from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateDevice
+from homeassistant.components.climate.const import (CURRENT_HVAC_HEAT,
+                                                    CURRENT_HVAC_IDLE, DOMAIN,
+                                                    HVAC_MODE_AUTO,
+                                                    HVAC_MODE_HEAT,
+                                                    HVAC_MODE_OFF,
+                                                    SERVICE_SET_PRESET_MODE,
+                                                    SERVICE_SET_TEMPERATURE,
+                                                    SUPPORT_PRESET_MODE,
+                                                    SUPPORT_TARGET_TEMPERATURE)
+from homeassistant.const import (ATTR_TEMPERATURE, CONF_HOST, CONF_NAME,
+                                 CONF_PASSWORD, CONF_PORT, CONF_USERNAME,
+                                 TEMP_CELSIUS)
 from homeassistant.exceptions import PlatformNotReady
 
-SUPPORT_FLAGS = ( SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE )
+SUPPORT_FLAGS = (SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,17 +48,18 @@ DEFAULT_NAME = 'Anna Thermostat'
 DEFAULT_USERNAME = 'smile'
 DEFAULT_TIMEOUT = 10
 DEFAULT_PORT = 80
-DEFAULT_ICON = "mdi:thermometer"
+DEFAULT_ICON = 'mdi:thermometer'
 
 # Hold modes
-PRESET_MODE_HOME = "home"
-PRESET_MODE_VACATION = "vacation"
-PRESET_MODE_NO_FROST = "no_frost"
-PRESET_MODE_SLEEP = "asleep"
-PRESET_MODE_AWAY = "away"
+PRESET_MODE_HOME = 'home'
+PRESET_MODE_VACATION = 'vacation'
+PRESET_MODE_NO_FROST = 'no_frost'
+PRESET_MODE_SLEEP = 'asleep'
+PRESET_MODE_AWAY = 'away'
 
-ATTR_PRESET_MODES = [ PRESET_MODE_HOME, PRESET_MODE_VACATION, PRESET_MODE_NO_FROST, PRESET_MODE_SLEEP, PRESET_MODE_AWAY ]
-ATTR_HVAC_MODES = [ HVAC_MODE_HEAT, HVAC_MODE_AUTO, HVAC_MODE_OFF ]
+ATTR_PRESET_MODES = [PRESET_MODE_HOME, PRESET_MODE_VACATION,
+                     PRESET_MODE_NO_FROST, PRESET_MODE_SLEEP, PRESET_MODE_AWAY]
+ATTR_HVAC_MODES = [HVAC_MODE_HEAT, HVAC_MODE_AUTO, HVAC_MODE_OFF]
 
 # Change defaults to match Anna
 DEFAULT_MIN_TEMP = 4
@@ -86,8 +76,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_PASSWORD): cv.string
 })
 
+
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup the Anna thermostat"""
+    """Setup the Anna thermostat."""
     add_devices([
         ThermostatDevice(
             config.get(CONF_NAME),
@@ -100,12 +91,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         )
     ])
 
-_LOGGER.debug("Anna: custom component loading (Anna PlugWise climate)")
 
 class ThermostatDevice(ClimateDevice):
-    """Representation of an Anna thermostat"""
-    def __init__(self, name, username, password, host, port, min_temp, max_temp):
-        _LOGGER.debug("Anna: Init called")
+    """Representation of an Anna thermostat."""
+    def __init__(self, name, username, password, host, port,
+                 min_temp, max_temp):
+        """Set up the Anna API."""
+        _LOGGER.debug("Init called")
         self._name = name
         self._username = username
         self._password = password
@@ -121,97 +113,32 @@ class ThermostatDevice(ClimateDevice):
         self._max_temp = max_temp
         self._hvac_modes = ATTR_HVAC_MODES
 
-        _LOGGER.debug("Anna: Initializing API")
+        _LOGGER.debug("Initializing API")
         import haanna
-        self._api = haanna.Haanna(self._username, self._password, self._host, self._port)
+        self._api = haanna.Haanna(self._username, self._password,
+                                  self._host, self._port)
         try:
-             self._api.ping_anna_thermostat()
-        except:
-            _LOGGER.error("Anna: Unable to ping, platform not ready")
+            self._api.ping_anna_thermostat()
+        except Exception:
+            _LOGGER.error("Unable to ping, platform not ready")
             raise PlatformNotReady
-        _LOGGER.debug("Anna: platform ready")
+        _LOGGER.debug("platform ready")
         self.update()
 
     @property
     def should_poll(self):
-        """Polling is needed"""
+        """Polling is needed."""
         return True
 
     @property
     def state(self):
-        """Return the current state"""
+        """Return the current state."""
         return self._state
 
     @property
-    def hvac_action(self):
-        """Return current running hvac"""
-        domain_objects = self._api.get_domain_objects()
-        #if self._api.get_mode(domain_objects) == True:
-        #  self._hvac_mode=CURRENT_HVAC_IDLE
-        #else:
-        #  self._hvac_mode=CURRENT_HVAC_OFF
-        if self._api.get_heating_status(domain_objects) == True:
-          self._state=CURRENT_HVAC_HEAT
-          return self._state
-        else:
-          self._state=CURRENT_HVAC_IDLE
-          return self._state
-
-    @property
-    def preset_mode(self):
-        """Polling is needed"""
-        return self._preset_mode
-
-    @property
-    def preset_modes(self):
-        """Polling is needed"""
-        return ATTR_PRESET_MODES
-
-    def update(self):
-        """Update the data from the thermostat"""
-        _LOGGER.debug("Anna: Update called")
-        domain_objects = self._api.get_domain_objects()
-        self._current_temperature = self._api.get_temperature(domain_objects)
-        self._outdoor_temperature = self._api.get_outdoor_temperature(domain_objects)
-        self._temperature = self._api.get_target_temperature(domain_objects)
-        self._preset_mode = self._api.get_current_preset(domain_objects)
-        #if self._api.get_mode(domain_objects) == True:
-        #  self._hvac_mode=HVAC_MODE_AUTO
-        #else:
-        #  self._hvac_mode=HVAC_MODE_OFF
-        #if self._api.get_heating_status(domain_objects) == True:
-        #  self._state=HVAC_MODE_HEAT
-        #else:
-        #  self._state=HVAC_MODE_OFF
-
-    @property
     def name(self):
+        """Return the name of the thermostat, if any."""
         return self._name
-
-    @property
-    def current_preset_mode(self):
-        """Return the current preset mode, e.g., home, away, temp."""
-        return self._preset_mode
-
-    @property
-    def preset_mode(self):
-        """Return the current preset mode, e.g., home, away, temp."""
-        return self._preset_mode
-
-    @property
-    def preset_modes(self):
-        """Return the vailable preset modes, e.g., home, away, temp."""
-        return ATTR_PRESET_MODES
-
-    @property
-    def hvac_modes(self):
-        """Return the operation modes list."""
-        return self._hvac_modes
-
-    @property
-    def hvac_mode(self):
-        """Return current operation ie. auto, idle."""
-        return self._hvac_mode
 
     @property
     def icon(self):
@@ -219,55 +146,109 @@ class ThermostatDevice(ClimateDevice):
         return DEFAULT_ICON
 
     @property
-    def current_temperature(self):
-        return self._current_temperature
-
-    @property
-    def min_temp(self):
-        return self._min_temp
-
-    @property
-    def max_temp(self):
-        return self._max_temp
-
-    @property
-    def target_temperature(self):
-        return self._temperature
-
-    @property
-    def outdoor_temperature(self):
-        return self._outdoor_temperature
-
-    @property
     def supported_features(self):
         """Return the list of supported features."""
         return SUPPORT_FLAGS
 
     @property
+    def device_state_attributes(self):
+        """Return the device specific state attributes."""
+        _attributes = {}
+        _attributes['outdoor_temperature'] = self._outdoor_temperature
+        return _attributes
+
+    def update(self):
+        """Update the data from the thermostat."""
+        _LOGGER.debug("Update called")
+        domain_objects = self._api.get_domain_objects()
+        self._current_temperature = self._api.get_temperature(domain_objects)
+        self._temperature = self._api.get_target_temperature(domain_objects)
+        self._preset_mode = self._api.get_current_preset(domain_objects)
+        self._outdoor_temperature = self._api.get_outdoor_temperature(
+             domain_objects)
+
+    @property
+    def hvac_action(self):
+        """Return current active hvac state."""
+        domain_objects = self._api.get_domain_objects()
+        if self._api.get_heating_status(domain_objects) is True:
+            self._state = CURRENT_HVAC_HEAT
+            return self._state
+        else:
+            self._state = CURRENT_HVAC_IDLE
+            return self._state
+
+    @property
+    def preset_mode(self):
+        """Return the active preset mode."""
+        return self._preset_mode
+
+    @property
+    def preset_modes(self):
+        """Return the available preset modes list."""
+        return ATTR_PRESET_MODES
+
+    @property
+    def hvac_mode(self):
+        """Return current operation ie. heating, idle."""
+        return self._hvac_mode
+
+    @property
+    def hvac_modes(self):
+        """Return the available hvac  modes list."""
+        return self._hvac_modes
+
+    @property
+    def current_temperature(self):
+        """Return the current temperature."""
+        return self._current_temperature
+
+    @property
+    def min_temp(self):
+        """Return the minimal temperature possible to set."""
+        return self._min_temp
+
+    @property
+    def max_temp(self):
+        """Return the maximum temperature possible to set."""
+        return self._max_temp
+
+    @property
+    def target_temperature(self):
+        """Return the target temperature."""
+        return self._temperature
+
+    @property
+    def outdoor_temperature(self):
+        """Return the outdoor temperature."""
+        return self._outdoor_temperature
+
+    @property
     def temperature_unit(self):
+        """Return the unit of measured temperature."""
         return TEMP_CELSIUS
 
     def set_temperature(self, **kwargs):
-        """Set new target temperature"""
-        _LOGGER.debug("Anna: Adjusting temperature")
+        """Set new target temperature."""
+        _LOGGER.debug("Adjusting temperature")
         temperature = kwargs.get(ATTR_TEMPERATURE)
-        if temperature is not None and temperature > CONF_MIN_TEMP and temperature < CONF_MAX_TEMP:
+        if (temperature is not None and temperature > CONF_MIN_TEMP and
+                temperature < CONF_MAX_TEMP):
             self._temperature = temperature
             domain_objects = self._api.get_domain_objects()
             self._api.set_temperature(domain_objects, temperature)
             self.schedule_update_ha_state()
-            _LOGGER.debug('Anna: Changing temporary temperature')
+            _LOGGER.debug("Changing temporary temperature")
         else:
-            _LOGGER.error('Anna: Failed to change temperature (invalid temperature given)')
+            _LOGGER.error("Invalid temperature requested")
 
     def set_preset_mode(self, preset_mode):
         """Set the preset mode."""
-        _LOGGER.debug("Anna: Adjusting preset_mode (i.e. preset)")
+        _LOGGER.debug("Adjusting preset_mode (i.e. preset)")
         if preset_mode is not None and preset_mode in ATTR_PRESET_MODES:
             domain_objects = self._api.get_domain_objects()
             self._preset_mode = preset_mode
             self._api.set_preset(domain_objects, preset_mode)
-            _LOGGER.debug('Anna: Changing preset mode/preset')
+            _LOGGER.debug("Changing preset mode")
         else:
-            _LOGGER.error('Anna: Failed to change preset mode (invalid or no preset given)')
-
+            _LOGGER.error("Invalid or no preset mode given")


### PR DESCRIPTION
This should fix #12 @bouwew 

```
hvac_modes: heat,auto,off
current_temperature: 24.3
min_temp: 4
max_temp: 30
temperature: 20
hvac_action: idle
preset_mode: home
preset_modes: home,vacation,no_frost,asleep,away
friendly_name: Anna Thermostat
icon: mdi:thermometer
supported_features: 17
```

Do note that this still doesn't make the schedule thing work, more work is required on that (and hass will just report 'can't call service'.
Giving it a test run (changing on app or browser directly to the `smile` updates `preset_mode` when updates are fetched. Pushing the temperature to 27 make `hvac_action` go into `heating` (after update) and after another update the device state moves from `idle` to `heating` as well.