### PR TITLE
Adding DHW-status and showing the various states via the preset_mode parameter

### DIFF
--- a/custom_components/plugwise_dev/climate.py
+++ b/custom_components/plugwise_dev/climate.py
@@ -186,7 +186,7 @@ class ThermostatDevice(ClimateDevice):
         """ Reset the manual_temp_change detection when a schedule-change happens and the schedule takes control again: """
         if (self.hvac_mode == HVAC_MODE_AUTO) and (schedule_temperature == self.thermostat_temperature):
             self._manual_temp_change = "false"
-        if (self.hvac_mode == HVAC_MODE_AUTO) and ((preset_mode == 'none') or (schedule_temperature == preset_temp)) and (self._manual_temp_change == "false"):
+        if (self.hvac_mode == HVAC_MODE_AUTO) and ((preset_mode == 'none') or (schedule_temperature != preset_temp)) and (self._manual_temp_change == "false"):
             return "{}".format(self._selected_schema)
         elif (preset_mode != 'none'):
             self._preset_temperature = self.current_temperature

--- a/custom_components/plugwise_dev/climate.py
+++ b/custom_components/plugwise_dev/climate.py
@@ -149,12 +149,9 @@ class ThermostatDevice(ClimateDevice):
 
     @property
     def preset_modes(self):
-        """Return the available preset modes list and store the values."""
-        presets = self._api.get_presets(self._domain_objects)
-        presets_list = list(presets)
-        temps=[]
-        for key,val in presets.items():
-            temps.append(val)
+        """Return the available preset modes list and make the presets with their temperatures available."""
+        self._presets = self._api.get_presets(self._domain_objects)
+        presets_list = list(self._presets)
         return presets_list
 
     @property
@@ -162,7 +159,10 @@ class ThermostatDevice(ClimateDevice):
         """Return the active schema when active, or the active preset mode or show a temporary temperature-change."""
         preset_mode = self._api.get_current_preset(self._domain_objects)
         self._selected_schema = self._api.get_active_schema_name(self._domain_objects)
-        if (self.hvac_mode == HVAC_MODE_AUTO) and (preset_mode == 'none') and (self._manual_temp_change == "false"):
+        schedule_temperature = self._api.get_schedule_temperature(self._domain_objects)
+        presets = self._api.get_presets(self._domain_objects)
+        preset_temp = presets.get(preset_mode, "none")
+        if (self.hvac_mode == HVAC_MODE_AUTO) and ((preset_mode == 'none') or (schedule_temperature == preset_temp)) and (self._manual_temp_change == "false"):
             return "{}".format(self._selected_schema)
         elif (preset_mode != 'none'):
             self._preset_temperature = self.current_temperature

--- a/custom_components/plugwise_dev/climate.py
+++ b/custom_components/plugwise_dev/climate.py
@@ -101,7 +101,6 @@ class ThermostatDevice(ClimateDevice):
         self._hvac_modes = ATTR_HVAC_MODES
         self._preset_temperature = min_temp
         self._manual_temp_change = "false"
- #       self._schedule_override = False
 
     @property
     def hvac_action(self):
@@ -165,16 +164,12 @@ class ThermostatDevice(ClimateDevice):
     def hvac_mode(self):
         """Return current active hvac state."""
         if self._api.get_schema_state(self._domain_objects) and (self._api.get_current_preset(self._domain_objects) != 'on'):
-#            self._schedule_override = False
             return HVAC_MODE_AUTO
         elif self._api.get_schema_state(self._domain_objects) and (self._api.get_current_preset(self._domain_objects) == 'on'):
-#            self._schedule_override = True
             return HVAC_MODE_AUTO
         elif not self._api.get_schema_state(self._domain_objects) and (self._api.get_current_preset(self._domain_objects) == 'on'):
-#            self._schedule_override = False
             return HVAC_MODE_HEAT
         else:
-#            self._schedule_override = True
             return HVAC_MODE_HEAT
 
     @property

--- a/custom_components/plugwise_dev/climate.py
+++ b/custom_components/plugwise_dev/climate.py
@@ -148,6 +148,16 @@ class ThermostatDevice(ClimateDevice):
         self._selected_schema = self._api.get_active_schema_name(self._domain_objects)
 
     @property
+    def preset_modes(self):
+        """Return the available preset modes list and store the values."""
+        presets = self._api.get_presets(self._domain_objects)
+        presets_list = list(presets)
+        temps=[]
+        for key,val in presets.items():
+            temps.append(val)
+        return presets_list
+
+    @property
     def preset_mode(self):
         """Return the active schema when active, or the active preset mode or show a temporary temperature-change."""
         preset_mode = self._api.get_current_preset(self._domain_objects)
@@ -173,17 +183,11 @@ class ThermostatDevice(ClimateDevice):
             return HVAC_MODE_HEAT
 
     @property
-    def current_temperature(self):
-        """Return the current temperature."""
-        return self._api.get_temperature(self._domain_objects)
+    def room_temperature(self):
+        """Return the current temperature of the room."""
+        return self._api.get_room_temperature(self._domain_objects)
         if (self._preset_temperature != self.current_temperature):
             self._manual_temp_change = "false"
-
-    @property
-    def preset_modes(self):
-        """Return the available preset modes list without values."""
-        presets = list(self._api.get_presets(self._domain_objects))
-        return presets
 
     @property
     def hvac_modes(self):
@@ -202,8 +206,17 @@ class ThermostatDevice(ClimateDevice):
 
     @property
     def target_temperature(self):
-        """Return the target temperature."""
+        """Return the active target temperature."""
         return self._api.get_target_temperature(self._domain_objects)
+
+    @property
+    def thermostat_temperature(self):
+        """
+        Return the thermostat set temperature. This setting directly follows the changes
+        in temperature from the interface or schedule. After a small delay, the target_temperature
+        value will change as well, this is some kind of filter-function.
+        """
+        return self._api.get_thermostat_temperature(self._domain_objects)
 
     @property
     def temperature_unit(self):

--- a/custom_components/plugwise_dev/climate.py
+++ b/custom_components/plugwise_dev/climate.py
@@ -180,8 +180,12 @@ class ThermostatDevice(ClimateDevice):
         schedule_temperature = self._api.get_schedule_temperature(self._domain_objects)
         presets = self._api.get_presets(self._domain_objects)
         preset_temp = presets.get(preset_mode, "none")
-        if (self.hvac_mode == HVAC_MODE_AUTO) and (preset_mode == self._preset_mode) and (schedule_temperature != self.thermostat_temperature):
+        """ Manual_temp_change detection: """
+        if (self.hvac_mode == HVAC_MODE_AUTO) and (schedule_temperature != self.thermostat_temperature):
             self._manual_temp_change = "true"
+        """ Reset the manual_temp_change detection when a schedule-change happens and the schedule takes control again: """
+        if (self.hvac_mode == HVAC_MODE_AUTO) and (schedule_temperature == self.thermostat_temperature):
+            self._manual_temp_change = "false"
         if (self.hvac_mode == HVAC_MODE_AUTO) and ((preset_mode == 'none') or (schedule_temperature == preset_temp)) and (self._manual_temp_change == "false"):
             return "{}".format(self._selected_schema)
         elif (preset_mode != 'none'):

--- a/custom_components/plugwise_dev/climate.py
+++ b/custom_components/plugwise_dev/climate.py
@@ -43,6 +43,9 @@ DEFAULT_ICON = "mdi:thermometer"
 DEFAULT_MIN_TEMP = 4
 DEFAULT_MAX_TEMP = 30
 
+# New CURRENT_HVAC mode
+CURRENT_HVAC_DHW = "dhw"
+
 # HVAC modes
 ATTR_HVAC_MODES = [HVAC_MODE_AUTO, HVAC_MODE_HEAT]
 
@@ -104,7 +107,10 @@ class ThermostatDevice(ClimateDevice):
         """Return the current action."""
         if self._api.get_heating_status(self._domain_objects):
             return CURRENT_HVAC_HEAT
-        return CURRENT_HVAC_IDLE
+        elif self._api.get_domestic_hot_water_status(self._domain_objects):
+            return CURRENT_HVAC_DHW
+        else:
+            return CURRENT_HVAC_IDLE
 
     @property
     def name(self):
@@ -146,9 +152,7 @@ class ThermostatDevice(ClimateDevice):
         """Return current active hvac state."""
         if self._api.get_schema_state(self._domain_objects):
             self._schedule_override = False
-            #self._hvac_mode = HVAC_MODE_AUTO
             return HVAC_MODE_AUTO
-        #self._hvac_mode = HVAC_MODE_HEAT
         self._schedule_override = True
         return HVAC_MODE_HEAT
 

--- a/custom_components/plugwise_dev/climate.py
+++ b/custom_components/plugwise_dev/climate.py
@@ -105,7 +105,7 @@ class ThermostatDevice(ClimateDevice):
     @property
     def hvac_action(self):
         """Return the current action."""
-        if self._api.get_heating_status(self._domain_objects):
+        if self._api.get_heating_status(self._domain_objects) and not self._api.get_domestic_hot_water_status(self._domain_objects):
             return CURRENT_HVAC_HEAT
         elif self._api.get_domestic_hot_water_status(self._domain_objects):
             return CURRENT_HVAC_DHW

--- a/custom_components/plugwise_dev/climate.py
+++ b/custom_components/plugwise_dev/climate.py
@@ -100,7 +100,7 @@ class ThermostatDevice(ClimateDevice):
         self._prev_preset_mode = "none"
         self._hvac_mode = None
         self._hvac_modes = ATTR_HVAC_MODES
-        self._tmp_preset_set = "false
+        self._tmp_preset_set = "false"
 
     @property
     def hvac_action(self):
@@ -177,7 +177,8 @@ class ThermostatDevice(ClimateDevice):
         From the XML the thermostat-value is used because it updates 'immediately' compared to the target_temperature-value.
         """
         if (self.preset_mode is not None): 
-            self._prev_preset_mode = self.preset_mode """save the previous preset_mode """
+            self._prev_preset_mode = self.preset_mode
+#	""" save the previous preset_mode """
 #        return self._api.get_target_temperature(self._domain_objects)
         return self.thermostat_temperature
 
@@ -191,15 +192,13 @@ class ThermostatDevice(ClimateDevice):
         schedule_temperature = self._api.get_schedule_temperature(self._domain_objects)
         presets = self._api.get_presets(self._domain_objects)
         preset_temperature = presets.get(preset_mode, "none")
-        if (self.hvac_mode == HVAC_MODE_AUTO) and (self.thermostat_temperature == schedule_temperature)):
+        if (self.hvac_mode == HVAC_MODE_AUTO) and (self.thermostat_temperature == schedule_temperature):
             return "{}".format(self._selected_schema)
         elif (self.hvac_mode == HVAC_MODE_AUTO) and (self._prev_preset_mode != preset_mode):
             self._tmp_preset_set = "true"
             return preset_mode
-        elif (self.hvac_mode == HVAC_MODE_AUTO) and 
-                    ((self.thermostat_temperature != schedule_temperature) and (self._prev_preset_mode == preset_mode)) or
-                    ((self._tmp_preset_set = "true") and (self.thermostat_temperature != preset_temperature)):
-            return "Temporary"        
+        elif (self.hvac_mode == HVAC_MODE_AUTO) and ((self.thermostat_temperature != schedule_temperature) and (self._prev_preset_mode == preset_mode)) or ((self._tmp_preset_set == "true") and (self.thermostat_temperature != preset_temperature)):
+            return "Temporary"
         
     @property
     def current_temperature(self):

--- a/custom_components/plugwise_dev/climate.py
+++ b/custom_components/plugwise_dev/climate.py
@@ -165,7 +165,7 @@ class ThermostatDevice(ClimateDevice):
         if (self.hvac_mode == HVAC_MODE_AUTO) and (preset_mode == 'none') and (self._manual_temp_change == "false"):
             return "{}".format(self._selected_schema)
         elif (preset_mode != 'none'):
-            self._preset_temperature = self.current_temperature
+            self._preset_temperature = self.room_temperature
             return preset_mode
         elif (self.hvac_mode == HVAC_MODE_AUTO) and (self._manual_temp_change == "true"):
             return "Temporary"
@@ -186,7 +186,7 @@ class ThermostatDevice(ClimateDevice):
     def room_temperature(self):
         """Return the current temperature of the room."""
         return self._api.get_room_temperature(self._domain_objects)
-        if (self._preset_temperature != self.current_temperature):
+        if (self._preset_temperature != self.room_temperature):
             self._manual_temp_change = "false"
 
     @property

--- a/custom_components/plugwise_dev/climate.py
+++ b/custom_components/plugwise_dev/climate.py
@@ -96,7 +96,8 @@ class ThermostatDevice(ClimateDevice):
         self._preset_mode = None
         self._hvac_mode = None
         self._hvac_modes = ATTR_HVAC_MODES
-        self._manual_temp_change = "false"
+        #self._manual_temp_change = False
+        self._schedule_override = False
 
     @property
     def hvac_action(self):
@@ -144,21 +145,25 @@ class ThermostatDevice(ClimateDevice):
     def hvac_mode(self):
         """Return current active hvac state."""
         if self._api.get_schema_state(self._domain_objects):
-            self._hvac_mode = HVAC_MODE_AUTO
+            self._schedule_override = False
             return HVAC_MODE_AUTO
-        self._hvac_mode = HVAC_MODE_HEAT
+        self._schedule_override = True
         return HVAC_MODE_HEAT
 
     @property
     def preset_mode(self):
         """Return the active preset mode."""
-        if self._manual_temp_change == "true":
-            self._manual_temp_change = "false"
-            return "Temporary"
-        elif self._hvac_mode == HVAC_MODE_AUTO:
-            return self._active_schema
-        else:
-            return self._api.get_current_preset(self._domain_objects)
+        preset = self._preset_mode
+        if self.hvac_mode == HVAC_MODE_AUTO:
+          return "{}".format(self._active_schema)
+        return preset
+        #if self._manual_temp_change == "true":
+        #    self._manual_temp_change = "false"
+        #    return "Tijdelijk"
+        #elif self._hvac_mode == HVAC_MODE_AUTO:
+        #    return self._active_schema
+        #else:
+        #    return self._api.get_current_preset(self._domain_objects)
 
     @property
     def preset_modes(self):
@@ -210,6 +215,7 @@ class ThermostatDevice(ClimateDevice):
     def set_hvac_mode(self, hvac_mode):
         """Set the hvac mode."""
         _LOGGER.debug("Adjusting hvac_mode (i.e. schedule/schema)")
+        self._preset_mode = None
         schema_mode = "false"
         if hvac_mode == HVAC_MODE_AUTO:
             schema_mode = "true"

--- a/custom_components/plugwise_dev/climate.py
+++ b/custom_components/plugwise_dev/climate.py
@@ -193,12 +193,8 @@ class ThermostatDevice(ClimateDevice):
     @property
     def hvac_mode(self):
         """Return current active hvac state."""
-        if self._api.get_schema_state(self._domain_objects) and (self._api.get_current_preset(self._domain_objects) != 'on'):
+        if self._api.get_schema_state(self._domain_objects):
             return HVAC_MODE_AUTO
-        elif self._api.get_schema_state(self._domain_objects) and (self._api.get_current_preset(self._domain_objects) == 'on'):
-            return HVAC_MODE_AUTO
-        elif not self._api.get_schema_state(self._domain_objects) and (self._api.get_current_preset(self._domain_objects) == 'on'):
-            return HVAC_MODE_HEAT
         else:
             return HVAC_MODE_HEAT
 

--- a/custom_components/plugwise_dev/climate.py
+++ b/custom_components/plugwise_dev/climate.py
@@ -165,7 +165,7 @@ class ThermostatDevice(ClimateDevice):
         if (self.hvac_mode == HVAC_MODE_AUTO) and (preset_mode == 'none') and (self._manual_temp_change == "false"):
             return "{}".format(self._selected_schema)
         elif (preset_mode != 'none'):
-            self._preset_temperature = self.room_temperature
+            self._preset_temperature = self.current_temperature
             return preset_mode
         elif (self.hvac_mode == HVAC_MODE_AUTO) and (self._manual_temp_change == "true"):
             return "Temporary"
@@ -183,10 +183,10 @@ class ThermostatDevice(ClimateDevice):
             return HVAC_MODE_HEAT
 
     @property
-    def room_temperature(self):
+    def current_temperature(self):
         """Return the current temperature of the room."""
         return self._api.get_room_temperature(self._domain_objects)
-        if (self._preset_temperature != self.room_temperature):
+        if (self._preset_temperature != self.current_temperature):
             self._manual_temp_change = "false"
 
     @property

--- a/custom_components/plugwise_dev/climate.py
+++ b/custom_components/plugwise_dev/climate.py
@@ -199,8 +199,8 @@ class ThermostatDevice(ClimateDevice):
         
     @property
     def current_temperature(self):
-        """Return the current temperature of the room."""
-        return self._api.get_room_temperature(self._domain_objects)
+        """Return the current room temperature."""
+        return self._api.get_current_temperature(self._domain_objects)
 
     @property
     def hvac_modes(self):

--- a/custom_components/plugwise_dev/manifest.json
+++ b/custom_components/plugwise_dev/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://github.com/laetificat/anna-ha",
   "dependencies": [],
   "codeowners": ["@laetificat","CoMPaTech"],
-  "requirements": ["haanna==0.10.0"]
+  "requirements": ["https://github.com/bouwew/haanna/archive/master.zip#haanna==0.11.2"]
 }


### PR DESCRIPTION
With these changes the HA climate card shows this:
![image](https://user-images.githubusercontent.com/11290930/64316851-4f1fea80-cfb6-11e9-8bc1-c3339fd17ef5.png)

"Idle -  Weekschema": shows the heating state (idle,heating) and the active temperature setting.
When the schema-icon is green - mode Auto: show the selected schedule (e.g. Weekschema), or the preset-name when the selected schedule is temporary overridden by a preset, or "Temporary" when overridden by a manual temperature change.
When the heating-icon is red -  mode Heating: show only the preset-name when a preset is active.

Unfortunately, the HA climate-card does not support showing DHW (domestic_hot_water). A change request / update is needed for this. Will be requested.

The code is working, tested in my system. These updates need to use "my" haanna 0.11.3 version, see my pull-request for haanna. The code can probably use some cleanup/optimization, my programming-skills are a bit limited, sorry.